### PR TITLE
Remove name of outdated RC

### DIFF
--- a/FsSonarRunner/FsSonarRunner.Test/packages.config
+++ b/FsSonarRunner/FsSonarRunner.Test/packages.config
@@ -8,5 +8,4 @@
   <package id="NUnit" version="3.7.1" targetFramework="net45" />
   <package id="System.Collections.Immutable" version="1.3.1" targetFramework="net45" />
   <package id="System.Reflection.Metadata" version="1.4.2" targetFramework="net45" />
-  <package id="System.Reflection.Metadata" version="1.4.1" targetFramework="net45" />
 </packages>

--- a/README.md
+++ b/README.md
@@ -1,33 +1,41 @@
-The plugin enables analysis of F# within SonarQube. 
+# SonarQube F# Code Analyzer Plugin
+
+The plugin enables analysis of F# within SonarQube.
 
 [![Build status](https://ci.appveyor.com/api/projects/status/jira637y22trnuc4?svg=true)](https://ci.appveyor.com/project/jorgecosta/sonar-fsharp-plugin-wxq94)
 
-Download latest snapshot from : https://ci.appveyor.com/project/jorgecosta/sonar-fsharp-plugin-wxq94/build/artifacts
+Download latest snapshot from : <https://ci.appveyor.com/project/jorgecosta/sonar-fsharp-plugin-wxq94/build/artifacts>
 
-# Description / Features
+## Description / Features
 
- - Metrics: LOC, number of classes, number of methods 
- - Code duplication detection
- - FSharpLint Support
- - Unit test metrics and Coverage
- - Runs under windows and Linux (mono)
- 
-# Configuration
-## Installation
+- Metrics: LOC, number of classes, number of methods
+- Code duplication detection
+- FSharpLint Support
+- Unit test metrics and Coverage
+- Runs under windows and Linux (mono)
+
+## Configuration
+
+### Installation
+
 Download the plugin from CI and copy to extensions/plugins in your SonarQube server installation. Restart the server and review the F# quality profile before running.
 
-## General Configuration
+### General Configuration
+
   sonar.fs.file.suffixes - files extensions to import
 
-## Coverage
- Generate reports and feed using the following properties
-   - sonar.fs.ncover3.reportsPaths 
-   - sonar.fs.opencover.reportsPaths
-   - sonar.fs.dotcover.reportsPaths
-   - sonar.fs.vscoveragexml.reportsPaths
+### Coverage
 
-## Test Reports
-Generate reports and feed using the following properties
-  - sonar.fs.vstest.reportsPaths
-  - sonar.fs.nunit.reportsPaths
+ Generate reports and feed using the following properties:
 
+- sonar.fs.ncover3.reportsPaths
+- sonar.fs.opencover.reportsPaths
+- sonar.fs.dotcover.reportsPaths
+- sonar.fs.vscoveragexml.reportsPaths
+
+### Test Reports
+
+Generate reports and feed using the following properties:
+
+- sonar.fs.vstest.reportsPaths
+- sonar.fs.nunit.reportsPaths

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ The plugin enables analysis of F# within SonarQube.
 
 [![Build status](https://ci.appveyor.com/api/projects/status/jira637y22trnuc4?svg=true)](https://ci.appveyor.com/project/jorgecosta/sonar-fsharp-plugin-wxq94)
 
-Download latest snapshot from : https://ci.appveyor.com/project/jorgecosta/sonar-fsharp-plugin-wxq94/build/artifacts -> ex : sonar-fsharp-plugin-1.0.RC1.jar artifact
+Download latest snapshot from : https://ci.appveyor.com/project/jorgecosta/sonar-fsharp-plugin-wxq94/build/artifacts
 
 # Description / Features
 

--- a/pom.xml
+++ b/pom.xml
@@ -13,6 +13,7 @@
   <version>1.0.3</version>
 
   <name>SonarQube F# Plugin</name>
+  <description>SonarQube F# Code Analyzer Plugin</description>
   <inceptionYear>2015</inceptionYear>
   <organization>
     <name>jmecsoftware.com/</name>

--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
@@ -23,15 +23,15 @@
     <connection>scm:git:git@github.com:jmecsoftware/sonar-fsharp-plugin.git</connection>
     <developerConnection>scm:git:git@github.com:jmecsoftware/sonar-fsharp-plugin.git</developerConnection>
     <url>https://github.com/jmecsoftware/sonar-fsharp-plugin</url>
-    <tag>1.0.2</tag>
+    <tag>1.0.3</tag>
   </scm>
   <issueManagement>
     <system>GitHub</system>
-    <url>https://github.com/jmecosta/sonar-fsharp-plugin/issues</url>
+    <url>https://github.com/jmecsoftware/sonar-fsharp-plugin/issues</url>
   </issueManagement>
 
   <modules>
-    <module>FsSonarRunner</module>  
+    <module>FsSonarRunner</module>
     <module>sonar-fsharp-plugin</module>
   </modules>
 


### PR DESCRIPTION
At the linked page only sonarqube-fsharp-plugin-1.0.3-sources.jar is available, which will also expire in next month.