### PR TITLE
Fix nuget configuration file

### DIFF
--- a/FsSonarRunner/FsSonarRunner.Test/packages.config
+++ b/FsSonarRunner/FsSonarRunner.Test/packages.config
@@ -8,5 +8,4 @@
   <package id="NUnit" version="3.7.1" targetFramework="net45" />
   <package id="System.Collections.Immutable" version="1.3.1" targetFramework="net45" />
   <package id="System.Reflection.Metadata" version="1.4.2" targetFramework="net45" />
-  <package id="System.Reflection.Metadata" version="1.4.1" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
Managing nuget packages for solution failed when opened the included solution file because of 
> \FsSonarRunner\FsSonarRunner.Test\packages.config': There are duplicate packages: System.Reflection.Metadata
