### PR TITLE
Rework of rules properties

### DIFF
--- a/sonar-fsharp-plugin/src/main/java/org/sonar/plugins/fsharp/FSharpRuleProperties.java
+++ b/sonar-fsharp-plugin/src/main/java/org/sonar/plugins/fsharp/FSharpRuleProperties.java
@@ -1,0 +1,88 @@
+/*
+ * Sonar FSharp Plugin, open source software quality management tool.
+ *
+ * Sonar FSharp Plugin is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * Sonar FSharp Plugin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ */
+package org.sonar.plugins.fsharp;
+
+import org.sonar.api.rule.Severity;
+
+import static java.util.Collections.unmodifiableMap;
+
+import java.util.HashMap;
+import java.util.Map;
+
+final class FSharpRuleProperties {
+    public static final Map<String, RuleProperty> ALL;
+
+    static {
+        Map<String, RuleProperty> rules = new HashMap<>();
+
+        // Typography
+        rules.put("RulesTypographyTrailingLineError", new RuleProperty(Severity.MAJOR, "File should not have a trailing new line", "<p></p>"));
+        rules.put("RulesTypographyTabCharacterError", new RuleProperty(Severity.MAJOR, "Tabulation character should not be used", "<p></p>"));
+        rules.put("RulesTypographyFileLengthError", new RuleProperty(Severity.MAJOR, "File should not have too many lines", "<p></p>"));
+        rules.put("RulesTypographyLineLengthError", new RuleProperty(Severity.MAJOR, "Lines should not be too long", "<p></p>"));
+        rules.put("RulesTypographyTrailingWhitespaceError", new RuleProperty(Severity.MAJOR, "Lines should not have trailing whitespace", "<p></p>"));
+
+        // nested statements
+        rules.put("RulesNestedStatementsError", new RuleProperty(Severity.MAJOR, "Maximum allowed of nesting", "<p></p>"));
+
+        // hint matcher - todo Map of list
+        rules.put("RulesHintRefactor", new RuleProperty(Severity.MAJOR, "Hint Refactor", "<p></p>"));
+        rules.put("RulesHintSuggestion", new RuleProperty(Severity.MAJOR, "Hint Suggestion", "<p></p>"));
+
+        rules.put("RulesXmlDocumentationExceptionError", new RuleProperty(Severity.INFO, "deprecated rule", "<p></p>"));
+        rules.put("RulesXmlDocumentationUnionError", new RuleProperty(Severity.INFO, "deprecated rule", "<p></p>"));
+        rules.put("RulesXmlDocumentationRecordError", new RuleProperty(Severity.INFO, "deprecated rule", "<p></p>"));
+        rules.put("RulesXmlDocumentationMemberError", new RuleProperty(Severity.INFO, "deprecated rule", "<p></p>"));
+        rules.put("RulesXmlDocumentationTypeError", new RuleProperty(Severity.INFO, "deprecated rule", "<p></p>"));
+        rules.put("RulesXmlDocumentationAutoPropertyError", new RuleProperty(Severity.INFO, "deprecated rule", "<p></p>"));
+        rules.put("RulesXmlDocumentationEnumError", new RuleProperty(Severity.INFO, "deprecated rule", "<p></p>"));
+        rules.put("RulesXmlDocumentationModuleError", new RuleProperty(Severity.INFO, "deprecated rule", "<p></p>"));
+        rules.put("RulesXmlDocumentationLetError", new RuleProperty(Severity.INFO, "deprecated rule", "<p></p>"));
+
+        // name convention
+        rules.put("RulesNamingConventionsInterfaceError", new RuleProperty(Severity.MAJOR, "Interface naming convention", "<p></p>"));
+        rules.put("RulesNamingConventionsExceptionError", new RuleProperty(Severity.MAJOR, "Exception naming convention", "<p></p>"));
+        rules.put("RulesNamingConventionsCamelCaseError", new RuleProperty(Severity.INFO, "deprecated rule", "<p></p>"));
+        rules.put("RulesNamingConventionsPascalCaseError", new RuleProperty(Severity.INFO, "deprecated rule", "<p></p>"));
+
+        // RaiseWithTooManyArguments
+        rules.put("RulesRaiseWithSingleArgument", new RuleProperty(Severity.MAJOR, "Expected raise to have a single argument", "<p></p>"));
+        rules.put("RulesFailwithWithSingleArgument", new RuleProperty(Severity.MAJOR, "Fail with should have a sigle argument", "<p></p>"));
+        rules.put("RulesNullArgWithSingleArgument", new RuleProperty(Severity.MAJOR, "Expected nullArg to have a single argument", "<p></p>"));
+        rules.put("RulesInvalidOpWithSingleArgument", new RuleProperty(Severity.MAJOR, "Expected invalidOp to have a single argument", "<p></p>"));
+        rules.put("RulesInvalidArgWithTwoArguments", new RuleProperty(Severity.MAJOR, "Expected invalidArg to have two arguments", "<p></p>"));
+        rules.put("RulesFailwithfWithArgumentsMatchingFormatString", new RuleProperty(Severity.MAJOR, "Expected failwithf's arguments to match the format string (there were too many arguments)", "<p></p>"));
+
+        // bindings
+        rules.put("RulesTupleOfWildcardsError", new RuleProperty(Severity.MAJOR, "A constructor argument in a pattern that is a tuple consisting of entirely wildcards can be replaced with a single wildcard", "<p></p>"));
+        rules.put("RulesWildcardNamedWithAsPattern", new RuleProperty(Severity.MAJOR, "Unnecessary wildcard named using the as pattern", "<p></p>"));
+        rules.put("RulesUselessBindingError", new RuleProperty(Severity.MAJOR, "Useless binding", "<p></p>"));
+        rules.put("RulesFavourIgnoreOverLetWildError", new RuleProperty(Severity.MAJOR, "Favour using the ignore function rather than let", "<p></p>"));
+
+        // function reinplementation
+        rules.put("RulesCanBeReplacedWithComposition", new RuleProperty(Severity.MAJOR, "Function composition should be used instead of current function", "<p></p>"));
+        rules.put("RulesReimplementsFunction", new RuleProperty(Severity.MAJOR, "Pointless function redefines", "<p></p>"));
+
+        // source length
+        rules.put("RulesSourceLengthError", new RuleProperty(Severity.MAJOR, "Source length check", "<p></p>"));
+
+        // NumberOfItems
+        rules.put("RulesNumberOfItemsTupleError", new RuleProperty(Severity.MAJOR, "The maximum number of tuples allowed", "<p></p>"));
+        rules.put("RulesNumberOfItemsClassMembersError", new RuleProperty(Severity.MAJOR, "The maximum number of members in class allowed", "<p></p>"));
+        rules.put("RulesNumberOfItemsFunctionError", new RuleProperty(Severity.MAJOR, "The maximum number of parameters allowed", "<p></p>"));
+        rules.put("RulesNumberOfItemsBooleanConditionsError", new RuleProperty(Severity.MAJOR, "Maximum allowed boolean operatores in condition", "<p></p>"));
+
+        ALL = unmodifiableMap(rules);
+    }
+}

--- a/sonar-fsharp-plugin/src/main/java/org/sonar/plugins/fsharp/FSharpSensor.java
+++ b/sonar-fsharp-plugin/src/main/java/org/sonar/plugins/fsharp/FSharpSensor.java
@@ -111,7 +111,6 @@ public class FSharpSensor implements Sensor {
       LOG.debug(command.toCommandLine());
       CommandExecutor.create().execute(command, new LogInfoStreamConsumer(), new LogErrorStreamConsumer(), Integer.MAX_VALUE);
     } catch (IOException e) {
-
       LOG.error("Could not write settings to file '{0}'", e.getMessage());
     }
   }
@@ -283,11 +282,10 @@ public class FSharpSensor implements Sensor {
         if (next == XMLStreamConstants.END_ELEMENT && "Token".equals(stream.getLocalName())) {
           cpdTokens.addToken(line, leftCol, line, rightCol, value);
 
-          try
-          {
-              if (highlight != null) {
-                  highlights.highlight(line, leftCol, line, rightCol, TypeOfText.valueOf(highlight));
-              }
+          try {
+            if (highlight != null) {
+              highlights.highlight(line, leftCol, line, rightCol, TypeOfText.valueOf(highlight));
+            }
 
           } catch (IllegalArgumentException ex) {
             LOG.error("Invalid token for hightlight : " + highlight + " : " + ex.getMessage());

--- a/sonar-fsharp-plugin/src/main/java/org/sonar/plugins/fsharp/FSharpSonarRulesDefinition.java
+++ b/sonar-fsharp-plugin/src/main/java/org/sonar/plugins/fsharp/FSharpSonarRulesDefinition.java
@@ -31,7 +31,7 @@ public class FSharpSonarRulesDefinition implements RulesDefinition {
     NewRule fileLines = createRule(repository, "RulesTypographyFileLengthError");
     fileLines.createParam("Lines").setDescription("The maximum number of lines allowed in a file")
       .setType(RuleParamType.INTEGER).setDefaultValue("1000");
-    NewRule lineLength = createRule(repository, "RulesTypographyLineLengthError")
+    NewRule lineLength = createRule(repository, "RulesTypographyLineLengthError");
     lineLength.createParam("Length").setDescription("The maximum authorized line length")
       .setType(RuleParamType.INTEGER).setDefaultValue("200");
     NewRule trailingWhiteSpace = createRule(repository, "RulesTypographyTrailingWhitespaceError");
@@ -56,7 +56,7 @@ public class FSharpSonarRulesDefinition implements RulesDefinition {
       .setType(RuleParamType.STRING).setDefaultValue("");
 
     // name convention
-    NewRule interfaceNaming = createRule(repository, "RulesNamingConventionsInterfaceError")
+    NewRule interfaceNaming = createRule(repository, "RulesNamingConventionsInterfaceError");
     NewRule exceptionNaming = createRule(repository, "RulesNamingConventionsExceptionError");
     NewRule typeNaming = repository.createRule("RulesNamingConventionsTypesError").setName("Type naming convention").setSeverity(Severity.MAJOR).setHtmlDescription("<p></p>");
     NewRule recordsNaming = repository.createRule("RulesNamingConventionsRecordsError").setName("Record naming convention").setSeverity(Severity.MAJOR).setHtmlDescription("<p></p>");

--- a/sonar-fsharp-plugin/src/main/java/org/sonar/plugins/fsharp/FSharpSonarRulesDefinition.java
+++ b/sonar-fsharp-plugin/src/main/java/org/sonar/plugins/fsharp/FSharpSonarRulesDefinition.java
@@ -19,7 +19,6 @@ import org.sonar.api.server.rule.RuleParamType;
 import org.sonar.api.server.rule.RulesDefinition;
 
 public class FSharpSonarRulesDefinition implements RulesDefinition {
-
   @Override
   public void define(Context context) {
     NewRepository repository = context
@@ -27,15 +26,15 @@ public class FSharpSonarRulesDefinition implements RulesDefinition {
       .setName(FSharpPlugin.REPOSITORY_NAME);
 
     // Typography
-    repository.createRule("RulesTypographyTrailingLineError").setName("File should not have a trailing new line").setSeverity(Severity.MAJOR).setHtmlDescription("<p></p>");
-    repository.createRule("RulesTypographyTabCharacterError").setName("Tabulation character should not be used").setSeverity(Severity.MAJOR).setHtmlDescription("<p></p>");
-    NewRule fileLines = repository.createRule("RulesTypographyFileLengthError").setName("File should not have too many lines").setSeverity(Severity.MAJOR).setHtmlDescription("<p></p>");
+    createRule(repository, "RulesTypographyTrailingLineError");
+    createRule(repository, "RulesTypographyTabCharacterError");
+    NewRule fileLines = createRule(repository, "RulesTypographyFileLengthError");
     fileLines.createParam("Lines").setDescription("The maximum number of lines allowed in a file")
       .setType(RuleParamType.INTEGER).setDefaultValue("1000");
-    NewRule lineLength = repository.createRule("RulesTypographyLineLengthError").setName("Lines should not be too long").setSeverity(Severity.MAJOR).setHtmlDescription("<p></p>");
+    NewRule lineLength = createRule(repository, "RulesTypographyLineLengthError")
     lineLength.createParam("Length").setDescription("The maximum authorized line length")
       .setType(RuleParamType.INTEGER).setDefaultValue("200");
-    NewRule trailingWhiteSpace = repository.createRule("RulesTypographyTrailingWhitespaceError").setName("Lines should not have trailing whitespace").setSeverity(Severity.MAJOR).setHtmlDescription("<p></p>");
+    NewRule trailingWhiteSpace = createRule(repository, "RulesTypographyTrailingWhitespaceError");
     trailingWhiteSpace.createParam("NumberOfSpacesAllowed").setDescription("Number of spaces allowed")
       .setType(RuleParamType.INTEGER).setDefaultValue("4");
     trailingWhiteSpace.createParam("OneSpaceAllowedAfterOperator").setDescription("Allow space after operator")
@@ -44,21 +43,21 @@ public class FSharpSonarRulesDefinition implements RulesDefinition {
       .setType(RuleParamType.BOOLEAN).setDefaultValue("true");
 
     // nested statements
-    NewRule nesting = repository.createRule("RulesNestedStatementsError").setName("Maximum allowed of nesting").setSeverity(Severity.MAJOR).setHtmlDescription("<p></p>");
+    NewRule nesting = createRule(repository, "RulesNestedStatementsError");
     nesting.createParam("Depth").setDescription("Maximum depth")
       .setType(RuleParamType.INTEGER).setDefaultValue("5");
 
     // hint matcher - todo Map of list
-    NewRule hintRefactor = repository.createRule("RulesHintRefactor").setName("Hint Refactor").setSeverity(Severity.MAJOR).setHtmlDescription("<p></p>");
+    NewRule hintRefactor = createRule(repository, "RulesHintRefactor");
     hintRefactor.createParam("Hints").setDescription("Hints to use")
       .setType(RuleParamType.STRING).setDefaultValue("");
-    NewRule hintSuggestions = repository.createRule("RulesHintSuggestion").setName("Hint Suggestion").setSeverity(Severity.MAJOR).setHtmlDescription("<p></p>");
+    NewRule hintSuggestions = createRule(repository, "RulesHintSuggestion");
     hintSuggestions.createParam("Hints").setDescription("Hints to use")
       .setType(RuleParamType.STRING).setDefaultValue("");
 
     // name convention
-    NewRule interfaceNaming = repository.createRule("RulesNamingConventionsInterfaceError").setName("Interface naming convention").setSeverity(Severity.MAJOR).setHtmlDescription("<p></p>");
-    NewRule exceptionNaming = repository.createRule("RulesNamingConventionsExceptionError").setName("Exception naming convention").setSeverity(Severity.MAJOR).setHtmlDescription("<p></p>");
+    NewRule interfaceNaming = createRule(repository, "RulesNamingConventionsInterfaceError")
+    NewRule exceptionNaming = createRule(repository, "RulesNamingConventionsExceptionError");
     NewRule typeNaming = repository.createRule("RulesNamingConventionsTypesError").setName("Type naming convention").setSeverity(Severity.MAJOR).setHtmlDescription("<p></p>");
     NewRule recordsNaming = repository.createRule("RulesNamingConventionsRecordsError").setName("Record naming convention").setSeverity(Severity.MAJOR).setHtmlDescription("<p></p>");
     NewRule enumNaming = repository.createRule("RulesNamingConventionsEnumError").setName("Enum naming convention").setSeverity(Severity.MAJOR).setHtmlDescription("<p></p>");
@@ -119,26 +118,25 @@ public class FSharpSonarRulesDefinition implements RulesDefinition {
     nonPublicNaming.createParam("Underscores").setDescription("Allow underscores: None(0), AllowPrefix(1), AllowAny(2)").setType(RuleParamType.multipleListOfValues("0", "1", "2")).setDefaultValue("0");
 
     // RaiseWithTooManyArguments
-    repository.createRule("RulesRaiseWithSingleArgument").setName("Expected raise to have a single argument").setSeverity(Severity.MAJOR).setHtmlDescription("<p></p>");
-    repository.createRule("RulesFailwithWithSingleArgument").setName("Fail with should have a sigle argument").setSeverity(Severity.MAJOR).setHtmlDescription("<p></p>");
-    repository.createRule("RulesNullArgWithSingleArgument").setName("Expected nullArg to have a single argument").setSeverity(Severity.MAJOR).setHtmlDescription("<p></p>");
-    repository.createRule("RulesInvalidOpWithSingleArgument").setName("Expected invalidOp to have a single argument").setSeverity(Severity.MAJOR).setHtmlDescription("<p></p>");
-    repository.createRule("RulesInvalidArgWithTwoArguments").setName("Expected invalidArg to have two arguments").setSeverity(Severity.MAJOR).setHtmlDescription("<p></p>");
-    repository.createRule("RulesFailwithfWithArgumentsMatchingFormatString").setName("Expected failwithf's arguments to match the format string (there were too many arguments)").setSeverity(Severity.MAJOR).setHtmlDescription("<p></p>");
+    createRule(repository, "RulesRaiseWithSingleArgument");
+    createRule(repository, "RulesFailwithWithSingleArgument");
+    createRule(repository, "RulesNullArgWithSingleArgument");
+    createRule(repository, "RulesInvalidOpWithSingleArgument");
+    createRule(repository, "RulesInvalidArgWithTwoArguments");
+    createRule(repository, "RulesFailwithfWithArgumentsMatchingFormatString");
 
     // bindings
-    repository.createRule("RulesTupleOfWildcardsError").setName("A constructor argument in a pattern that is a tuple consisting of entirely wildcards can be replaced with a single wildcard").setSeverity(Severity.MAJOR).setHtmlDescription("<p></p>");
-    repository.createRule("RulesWildcardNamedWithAsPattern").setName("Unnecessary wildcard named using the as pattern").setSeverity(Severity.MAJOR).setHtmlDescription("<p></p>");
-    repository.createRule("RulesUselessBindingError").setName("Useless binding").setSeverity(Severity.MAJOR).setHtmlDescription("<p></p>");
-    repository.createRule("RulesFavourIgnoreOverLetWildError").setName("Favour using the ignore function rather than let").setSeverity(Severity.MAJOR).setHtmlDescription("<p></p>");
-
+    createRule(repository, "RulesTupleOfWildcardsError");
+    createRule(repository, "RulesWildcardNamedWithAsPattern");
+    createRule(repository, "RulesUselessBindingError");
+    createRule(repository, "RulesFavourIgnoreOverLetWildError");
 
     // function reinplementation
-    repository.createRule("RulesCanBeReplacedWithComposition").setName("Function composition should be used instead of current function").setSeverity(Severity.MAJOR).setHtmlDescription("<p></p>");
-    repository.createRule("RulesReimplementsFunction").setName("Pointless function redefines").setSeverity(Severity.MAJOR).setHtmlDescription("<p></p>");
+    createRule(repository, "RulesCanBeReplacedWithComposition");
+    createRule(repository, "RulesReimplementsFunction");
 
     // source length
-    NewRule fileLines2 = repository.createRule("RulesSourceLengthError").setName("Source length check").setSeverity(Severity.MAJOR).setHtmlDescription("<p></p>");
+    NewRule fileLines2 = createRule(repository, "RulesSourceLengthError");
     fileLines2.createParam("MaxLinesInFunction").setDescription("The maximum lines in function - 0 means disable")
       .setType(RuleParamType.INTEGER).setDefaultValue("300");
     fileLines2.createParam("MaxLinesInLambdaFunction").setDescription("The maximum lines in lambda function - 0 means disable")
@@ -164,45 +162,47 @@ public class FSharpSonarRulesDefinition implements RulesDefinition {
     fileLines2.createParam("MaxLinesInModule").setDescription("The maximum lines in module - 0 means disable")
       .setType(RuleParamType.INTEGER).setDefaultValue("1000");
 
-
     // NumberOfItems
-    NewRule tuples = repository.createRule("RulesNumberOfItemsTupleError").setName("The maximum number of tuples allowed").setSeverity(Severity.MAJOR).setHtmlDescription("<p></p>");
+    NewRule tuples = createRule(repository, "RulesNumberOfItemsTupleError");
     tuples.createParam("MaxItems").setDescription("Maximum allowed values")
       .setType(RuleParamType.INTEGER).setDefaultValue("5");
-    NewRule parameters = repository.createRule("RulesNumberOfItemsClassMembersError").setName("The maximum number of members in class allowed").setSeverity(Severity.MAJOR).setHtmlDescription("<p></p>");
+    NewRule parameters = createRule(repository, "RulesNumberOfItemsClassMembersError");
     parameters.createParam("MaxItems").setDescription("Maximum allowed values")
       .setType(RuleParamType.INTEGER).setDefaultValue("5");
-    NewRule members = repository.createRule("RulesNumberOfItemsFunctionError").setName("The maximum number of parameters allowed").setSeverity(Severity.MAJOR).setHtmlDescription("<p></p>");
+    NewRule members = createRule(repository, "RulesNumberOfItemsFunctionError");
     members.createParam("MaxItems").setDescription("Maximum allowed values")
       .setType(RuleParamType.INTEGER).setDefaultValue("5");
-    NewRule booleanOperators = repository.createRule("RulesNumberOfItemsBooleanConditionsError").setName("Maximum allowed boolean operatores in condition").setSeverity(Severity.MAJOR).setHtmlDescription("<p></p>");
+    NewRule booleanOperators = createRule(repository, "RulesNumberOfItemsBooleanConditionsError");
     booleanOperators.createParam("MaxItems").setDescription("Maximum allowed values")
       .setType(RuleParamType.INTEGER).setDefaultValue("4");
 
     // RulesRedundantNewKeyword
     repository.createRule("RulesRedundantNewKeyword").setName("Redudant usage of new Keywork").setSeverity(Severity.MAJOR).setHtmlDescription("<p></p>");
 
-
     // lint errors
     repository.createRule("LintSourceError").setName("Parsing errors").setSeverity(Severity.INFO).setHtmlDescription("<p></p>");
     repository.createRule("LintError").setName("Lint errors").setSeverity(Severity.INFO).setHtmlDescription("<p></p>");
 
+    createRule(repository, "RulesXmlDocumentationExceptionError");
+    createRule(repository, "RulesXmlDocumentationUnionError");
+    createRule(repository, "RulesXmlDocumentationRecordError");
+    createRule(repository, "RulesXmlDocumentationMemberError");
+    createRule(repository, "RulesXmlDocumentationTypeError");
+    createRule(repository, "RulesXmlDocumentationAutoPropertyError");
 
-    repository.createRule("RulesXmlDocumentationExceptionError").setName("deprecated rule").setSeverity(Severity.INFO).setHtmlDescription("<p></p>");
-    repository.createRule("RulesXmlDocumentationUnionError").setName("deprecated rule").setSeverity(Severity.INFO).setHtmlDescription("<p></p>");
-    repository.createRule("RulesXmlDocumentationRecordError").setName("deprecated rule").setSeverity(Severity.INFO).setHtmlDescription("<p></p>");
-    repository.createRule("RulesXmlDocumentationMemberError").setName("deprecated rule").setSeverity(Severity.INFO).setHtmlDescription("<p></p>");
-    repository.createRule("RulesXmlDocumentationTypeError").setName("deprecated rule").setSeverity(Severity.INFO).setHtmlDescription("<p></p>");
-    repository.createRule("RulesXmlDocumentationAutoPropertyError").setName("deprecated rule").setSeverity(Severity.INFO).setHtmlDescription("<p></p>");
+    createRule(repository, "RulesXmlDocumentationEnumError");
+    createRule(repository, "RulesXmlDocumentationModuleError");
+    createRule(repository, "RulesXmlDocumentationLetError");
 
-    repository.createRule("RulesXmlDocumentationEnumError").setName("deprecated rule").setSeverity(Severity.INFO).setHtmlDescription("<p></p>");
-    repository.createRule("RulesXmlDocumentationModuleError").setName("deprecated rule").setSeverity(Severity.INFO).setHtmlDescription("<p></p>");
-    repository.createRule("RulesXmlDocumentationLetError").setName("deprecated rule").setSeverity(Severity.INFO).setHtmlDescription("<p></p>");
-
-    repository.createRule("RulesNamingConventionsCamelCaseError").setName("deprecated rule").setSeverity(Severity.INFO).setHtmlDescription("<p></p>");
-    repository.createRule("RulesNamingConventionsPascalCaseError").setName("deprecated rule").setSeverity(Severity.INFO).setHtmlDescription("<p></p>");
+    createRule(repository, "RulesNamingConventionsCamelCaseError");
+    createRule(repository, "RulesNamingConventionsPascalCaseError");
 
     repository.done();
   }
 
+  private static NewRule createRule(NewExtendedRepository repository, String ruleKey)
+  {
+    RuleProperty p = FSharpRuleProperties.ALL.get(ruleKey);
+    return repository.createRule(ruleKey).setName(p.getName()).setSeverity(p.getSeverity()).setHtmlDescription(p.getHtmlDescription());
+  }
 }

--- a/sonar-fsharp-plugin/src/main/java/org/sonar/plugins/fsharp/FSharpSonarWayProfile.java
+++ b/sonar-fsharp-plugin/src/main/java/org/sonar/plugins/fsharp/FSharpSonarWayProfile.java
@@ -13,7 +13,6 @@
  */
 package org.sonar.plugins.fsharp;
 
-import org.sonar.api.rule.Severity;
 import org.sonar.api.server.profile.BuiltInQualityProfilesDefinition;
 
 public class FSharpSonarWayProfile implements BuiltInQualityProfilesDefinition {
@@ -25,44 +24,7 @@ public class FSharpSonarWayProfile implements BuiltInQualityProfilesDefinition {
             FSharpPlugin.FSHARP_WAY_PROFILE, FSharpPlugin.LANGUAGE_KEY);
 
     profile.setDefault(true);
-    activateRule(profile, "RulesTypographyTrailingLineError", Severity.MAJOR);
-    activateRule(profile, "RulesTypographyTabCharacterError", Severity.MAJOR);
-    activateRule(profile, "RulesTypographyFileLengthError", Severity.MAJOR);
-    activateRule(profile, "RulesTypographyLineLengthError", Severity.MAJOR);
-    activateRule(profile, "RulesTypographyTrailingWhitespaceError", Severity.MAJOR);
-    activateRule(profile, "RulesNestedStatementsError", Severity.MAJOR);
-    activateRule(profile, "RulesHintRefactor", Severity.MAJOR);
-    activateRule(profile, "RulesHintSuggestion", Severity.MAJOR);
-    activateRule(profile, "RulesXmlDocumentationExceptionError", Severity.MAJOR);
-    activateRule(profile, "RulesXmlDocumentationUnionError", Severity.MAJOR);
-    activateRule(profile, "RulesXmlDocumentationRecordError", Severity.MAJOR);
-    activateRule(profile, "RulesXmlDocumentationMemberError", Severity.MAJOR);
-    activateRule(profile, "RulesXmlDocumentationTypeError", Severity.MAJOR);
-    activateRule(profile, "RulesXmlDocumentationAutoPropertyError", Severity.MAJOR);
-    activateRule(profile, "RulesXmlDocumentationEnumError", Severity.MAJOR);
-    activateRule(profile, "RulesXmlDocumentationModuleError", Severity.MAJOR);
-    activateRule(profile, "RulesXmlDocumentationLetError", Severity.MAJOR);
-    activateRule(profile, "RulesNamingConventionsExceptionError", Severity.MAJOR);
-    activateRule(profile, "RulesNamingConventionsCamelCaseError", Severity.MAJOR);
-    activateRule(profile, "RulesNamingConventionsPascalCaseError", Severity.MAJOR);
-    activateRule(profile, "RulesNamingConventionsInterfaceError", Severity.MAJOR);
-    activateRule(profile, "RulesRaiseWithSingleArgument", Severity.MAJOR);
-    activateRule(profile, "RulesFailwithWithSingleArgument", Severity.MAJOR);
-    activateRule(profile, "RulesNullArgWithSingleArgument", Severity.MAJOR);
-    activateRule(profile, "RulesInvalidOpWithSingleArgument", Severity.MAJOR);
-    activateRule(profile, "RulesInvalidArgWithTwoArguments", Severity.MAJOR);
-    activateRule(profile, "RulesFailwithfWithArgumentsMatchingFormatString", Severity.MAJOR);
-    activateRule(profile, "RulesTupleOfWildcardsError", Severity.MAJOR);
-    activateRule(profile, "RulesWildcardNamedWithAsPattern", Severity.MAJOR);
-    activateRule(profile, "RulesUselessBindingError", Severity.MAJOR);
-    activateRule(profile, "RulesFavourIgnoreOverLetWildError", Severity.MAJOR);
-    activateRule(profile, "RulesCanBeReplacedWithComposition", Severity.MAJOR);
-    activateRule(profile, "RulesReimplementsFunction", Severity.MAJOR);
-    activateRule(profile, "RulesSourceLengthError", Severity.MAJOR);
-    activateRule(profile, "RulesNumberOfItemsTupleError", Severity.MAJOR);
-    activateRule(profile, "RulesNumberOfItemsClassMembersError", Severity.MAJOR);
-    activateRule(profile, "RulesNumberOfItemsFunctionError", Severity.MAJOR);
-    activateRule(profile, "RulesNumberOfItemsBooleanConditionsError", Severity.MAJOR);
+    FSharpRuleProperties.ALL.forEach((k, p) -> activateRule(profile, k, p.getSeverity()));
     profile.done();
   }
 

--- a/sonar-fsharp-plugin/src/main/java/org/sonar/plugins/fsharp/FSharpSonarWayProfile.java
+++ b/sonar-fsharp-plugin/src/main/java/org/sonar/plugins/fsharp/FSharpSonarWayProfile.java
@@ -13,6 +13,7 @@
  */
 package org.sonar.plugins.fsharp;
 
+import org.sonar.api.rule.Severity;
 import org.sonar.api.server.profile.BuiltInQualityProfilesDefinition;
 
 public class FSharpSonarWayProfile implements BuiltInQualityProfilesDefinition {
@@ -24,44 +25,44 @@ public class FSharpSonarWayProfile implements BuiltInQualityProfilesDefinition {
             FSharpPlugin.FSHARP_WAY_PROFILE, FSharpPlugin.LANGUAGE_KEY);
 
     profile.setDefault(true);
-    activateRule(profile, "RulesTypographyTrailingLineError", "MAJOR");
-    activateRule(profile, "RulesTypographyTabCharacterError", "MAJOR");
-    activateRule(profile, "RulesTypographyFileLengthError", "MAJOR");
-    activateRule(profile, "RulesTypographyLineLengthError", "MAJOR");
-    activateRule(profile, "RulesTypographyTrailingWhitespaceError", "MAJOR");
-    activateRule(profile, "RulesNestedStatementsError", "MAJOR");
-    activateRule(profile, "RulesHintRefactor", "MAJOR");
-    activateRule(profile, "RulesHintSuggestion", "MAJOR");
-    activateRule(profile, "RulesXmlDocumentationExceptionError", "MAJOR");
-    activateRule(profile, "RulesXmlDocumentationUnionError", "MAJOR");
-    activateRule(profile, "RulesXmlDocumentationRecordError", "MAJOR");
-    activateRule(profile, "RulesXmlDocumentationMemberError", "MAJOR");
-    activateRule(profile, "RulesXmlDocumentationTypeError", "MAJOR");
-    activateRule(profile, "RulesXmlDocumentationAutoPropertyError", "MAJOR");
-    activateRule(profile, "RulesXmlDocumentationEnumError", "MAJOR");
-    activateRule(profile, "RulesXmlDocumentationModuleError", "MAJOR");
-    activateRule(profile, "RulesXmlDocumentationLetError", "MAJOR");
-    activateRule(profile, "RulesNamingConventionsExceptionError", "MAJOR");
-    activateRule(profile, "RulesNamingConventionsCamelCaseError", "MAJOR");
-    activateRule(profile, "RulesNamingConventionsPascalCaseError", "MAJOR");
-    activateRule(profile, "RulesNamingConventionsInterfaceError", "MAJOR");
-    activateRule(profile, "RulesRaiseWithSingleArgument", "MAJOR");
-    activateRule(profile, "RulesFailwithWithSingleArgument", "MAJOR");
-    activateRule(profile, "RulesNullArgWithSingleArgument", "MAJOR");
-    activateRule(profile, "RulesInvalidOpWithSingleArgument", "MAJOR");
-    activateRule(profile, "RulesInvalidArgWithTwoArguments", "MAJOR");
-    activateRule(profile, "RulesFailwithfWithArgumentsMatchingFormatString", "MAJOR");
-    activateRule(profile, "RulesTupleOfWildcardsError", "MAJOR");
-    activateRule(profile, "RulesWildcardNamedWithAsPattern", "MAJOR");
-    activateRule(profile, "RulesUselessBindingError", "MAJOR");
-    activateRule(profile, "RulesFavourIgnoreOverLetWildError", "MAJOR");
-    activateRule(profile, "RulesCanBeReplacedWithComposition", "MAJOR");
-    activateRule(profile, "RulesReimplementsFunction", "MAJOR");
-    activateRule(profile, "RulesSourceLengthError", "MAJOR");
-    activateRule(profile, "RulesNumberOfItemsTupleError", "MAJOR");
-    activateRule(profile, "RulesNumberOfItemsClassMembersError", "MAJOR");
-    activateRule(profile, "RulesNumberOfItemsFunctionError", "MAJOR");
-    activateRule(profile, "RulesNumberOfItemsBooleanConditionsError", "MAJOR");
+    activateRule(profile, "RulesTypographyTrailingLineError", Severity.MAJOR);
+    activateRule(profile, "RulesTypographyTabCharacterError", Severity.MAJOR);
+    activateRule(profile, "RulesTypographyFileLengthError", Severity.MAJOR);
+    activateRule(profile, "RulesTypographyLineLengthError", Severity.MAJOR);
+    activateRule(profile, "RulesTypographyTrailingWhitespaceError", Severity.MAJOR);
+    activateRule(profile, "RulesNestedStatementsError", Severity.MAJOR);
+    activateRule(profile, "RulesHintRefactor", Severity.MAJOR);
+    activateRule(profile, "RulesHintSuggestion", Severity.MAJOR);
+    activateRule(profile, "RulesXmlDocumentationExceptionError", Severity.MAJOR);
+    activateRule(profile, "RulesXmlDocumentationUnionError", Severity.MAJOR);
+    activateRule(profile, "RulesXmlDocumentationRecordError", Severity.MAJOR);
+    activateRule(profile, "RulesXmlDocumentationMemberError", Severity.MAJOR);
+    activateRule(profile, "RulesXmlDocumentationTypeError", Severity.MAJOR);
+    activateRule(profile, "RulesXmlDocumentationAutoPropertyError", Severity.MAJOR);
+    activateRule(profile, "RulesXmlDocumentationEnumError", Severity.MAJOR);
+    activateRule(profile, "RulesXmlDocumentationModuleError", Severity.MAJOR);
+    activateRule(profile, "RulesXmlDocumentationLetError", Severity.MAJOR);
+    activateRule(profile, "RulesNamingConventionsExceptionError", Severity.MAJOR);
+    activateRule(profile, "RulesNamingConventionsCamelCaseError", Severity.MAJOR);
+    activateRule(profile, "RulesNamingConventionsPascalCaseError", Severity.MAJOR);
+    activateRule(profile, "RulesNamingConventionsInterfaceError", Severity.MAJOR);
+    activateRule(profile, "RulesRaiseWithSingleArgument", Severity.MAJOR);
+    activateRule(profile, "RulesFailwithWithSingleArgument", Severity.MAJOR);
+    activateRule(profile, "RulesNullArgWithSingleArgument", Severity.MAJOR);
+    activateRule(profile, "RulesInvalidOpWithSingleArgument", Severity.MAJOR);
+    activateRule(profile, "RulesInvalidArgWithTwoArguments", Severity.MAJOR);
+    activateRule(profile, "RulesFailwithfWithArgumentsMatchingFormatString", Severity.MAJOR);
+    activateRule(profile, "RulesTupleOfWildcardsError", Severity.MAJOR);
+    activateRule(profile, "RulesWildcardNamedWithAsPattern", Severity.MAJOR);
+    activateRule(profile, "RulesUselessBindingError", Severity.MAJOR);
+    activateRule(profile, "RulesFavourIgnoreOverLetWildError", Severity.MAJOR);
+    activateRule(profile, "RulesCanBeReplacedWithComposition", Severity.MAJOR);
+    activateRule(profile, "RulesReimplementsFunction", Severity.MAJOR);
+    activateRule(profile, "RulesSourceLengthError", Severity.MAJOR);
+    activateRule(profile, "RulesNumberOfItemsTupleError", Severity.MAJOR);
+    activateRule(profile, "RulesNumberOfItemsClassMembersError", Severity.MAJOR);
+    activateRule(profile, "RulesNumberOfItemsFunctionError", Severity.MAJOR);
+    activateRule(profile, "RulesNumberOfItemsBooleanConditionsError", Severity.MAJOR);
     profile.done();
   }
 

--- a/sonar-fsharp-plugin/src/main/java/org/sonar/plugins/fsharp/RuleProperty.java
+++ b/sonar-fsharp-plugin/src/main/java/org/sonar/plugins/fsharp/RuleProperty.java
@@ -1,0 +1,38 @@
+/*
+ * Sonar FSharp Plugin, open source software quality management tool.
+ *
+ * Sonar FSharp Plugin is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * Sonar FSharp Plugin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ */
+package org.sonar.plugins.fsharp;
+
+class RuleProperty {
+    private String name;
+    private String severity;
+    private String htmlDescription;
+
+    public RuleProperty(String severity, String name, String htmlDescription) {
+        this.severity = severity;
+        this.name = name;
+        this.htmlDescription = htmlDescription;
+    }
+
+    public String getHtmlDescription() {
+        return htmlDescription;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getSeverity() {
+        return severity;
+    }
+}

--- a/sonar-fsharp-plugin/src/main/java/org/sonar/plugins/fsharp/utils/UnZip.java
+++ b/sonar-fsharp-plugin/src/main/java/org/sonar/plugins/fsharp/utils/UnZip.java
@@ -25,61 +25,60 @@ import org.sonar.api.utils.log.Loggers;
 
 // https://www.mkyong.com/java/how-to-decompress-files-from-a-zip-file/
 
-public class UnZip
-{
+public class UnZip {
   public static final Logger LOG = Loggers.get(UnZip.class);
   List<String> fileList;
 
   /**
    * Unzip it
+   *
    * @param zipFile input zip file
-   * @param output zip file output folder
+   * @param output  zip file output folder
    */
-  public void unZipIt(String zipFile, String outputFolder) throws IOException{
+  public void unZipIt(String zipFile, String outputFolder) throws IOException {
 
     byte[] buffer = new byte[1024];
 
-    try{
+    try {
 
-      //create output directory is not exists
+      // create output directory is not exists
       File folder = new File(outputFolder);
-      if(!folder.exists()){
-          folder.mkdir();
+      if (!folder.exists()) {
+        folder.mkdir();
       }
 
-      //get the zip file content
-      ZipInputStream zis =
-          new ZipInputStream(new FileInputStream(zipFile));
-      //get the zipped file list entry
+      // get the zip file content
+      ZipInputStream zis = new ZipInputStream(new FileInputStream(zipFile));
+      // get the zipped file list entry
       ZipEntry ze = zis.getNextEntry();
 
-      while(ze!=null){
+      while (ze != null) {
 
-         String fileName = ze.getName();
-         File newFile = new File(outputFolder + File.separator + fileName);
+        String fileName = ze.getName();
+        File newFile = new File(outputFolder + File.separator + fileName);
 
-         LOG.debug("Unzip {}", newFile.getAbsolutePath());
+        LOG.debug("Unzip {}", newFile.getAbsolutePath());
 
-          //create all non exists folders
-          //else you will hit FileNotFoundException for compressed folder
-          new File(newFile.getParent()).mkdirs();
+        // create all non exists folders
+        // else you will hit FileNotFoundException for compressed folder
+        new File(newFile.getParent()).mkdirs();
 
-          FileOutputStream fos = new FileOutputStream(newFile);
+        FileOutputStream fos = new FileOutputStream(newFile);
 
-          int len;
-          while ((len = zis.read(buffer)) > 0) {
+        int len;
+        while ((len = zis.read(buffer)) > 0) {
           fos.write(buffer, 0, len);
-          }
+        }
 
-          fos.close();
-          ze = zis.getNextEntry();
+        fos.close();
+        ze = zis.getNextEntry();
       }
 
       zis.closeEntry();
       zis.close();
 
       LOG.debug("Unzip Done.");
-    }catch(IOException ex){
+    } catch (IOException ex) {
       LOG.error("Unzip Failed {}", ex.getMessage());
       throw ex;
     }


### PR DESCRIPTION
- rules of severity info in 1.0.6.110 reset from Major to info, see issue #57 
- use constrants from `org.sonar.api.rule.Severity` instead of strings
- some refactoring

Open Points:
- [ ] In `org.sonar.plugins.fsharp.FSharpSonarRulesDefinition` there are 16 additional rules which are not activated in `FSharpSonarWayProfile`. Some of them should IMHO included, eg _RulesRedundantNewKeyword_ Why are These rules not included? Any history behind it? These rules are unchanged for now.
- [x] `RuleProperty` - Constructor and getters or a pure bean with getters and setters.
- [x] Missing HtmlDesicription of the rules are in _sonar-fsharp-plugin\src\main\resources\org\sonar\l10n\fsharp\rules_?
- [x] why set priority in `org.sonar.plugins.fsharp.FSharpSonarWayProfile.activateRule` as it is already set in `FSharpSonarRulesDefinition` while creating the rules? 

@jmecosta Feel free to commit to this branch on any of the above open points