### PR TITLE
exception thrown when option /d with one argument

### DIFF
--- a/FsSonarRunner/FsSonarRunner/App.config
+++ b/FsSonarRunner/FsSonarRunner/App.config
@@ -12,7 +12,7 @@
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Build.Framework" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-14.0.0.0" newVersion="4.0.0.0" />
-      </dependentAssembly>      
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 </configuration>

--- a/FsSonarRunner/FsSonarRunner/Program.fs
+++ b/FsSonarRunner/FsSonarRunner/Program.fs
@@ -70,7 +70,11 @@ let main argv =
             fsfiles |> Seq.iter (fun c -> metrics.RunAnalyses(c, File.ReadAllText(c), ""))
             fsxfiles |> Seq.iter (fun c -> metrics.RunAnalyses(c, File.ReadAllText(c), ""))
 
-            metrics.WriteXmlToDisk(argv.[2], true)
+            if arguments.ContainsKey("o")
+            then
+                let xmlOutPath = arguments.["o"] |> Seq.head
+                metrics.WriteXmlToDisk(xmlOutPath, true)
+            metrics.PrintIssues()
         with
         | ex -> printf "    Failed: %A" ex
     else


### PR DESCRIPTION
when `FsSonarRunner.exe /d <directory to analyse>` is executed an ArrayOutOfRangeException is thrown

Two possible solutions:
- [implemented] use `/o <output XML file>` for output and otherwise print to console only 
- fix implementation and help that `/d` expect two arguments: directory and output file

As there is anyway the `/o` argument the first solution was implemented. Do you accept my choice?

NB: In net472 slightly modified fix. net472 didn't compile in master.