### PR TITLE
Replace URI with absolute path for files to analyze

### DIFF
--- a/FsSonarRunner/FsSonarRunner/Program.fs
+++ b/FsSonarRunner/FsSonarRunner/Program.fs
@@ -67,7 +67,7 @@ let main argv =
                     printf "    [FsSonarRunner] [Error]: %s not found \r\n" file
 
             options.Files
-            |> Seq.iter (fun file -> handleFileToAnalyse(file.Replace("file:///", "")))
+            |> Seq.iter handleFileToAnalyse
 
             writeMetrics metrics
         with

--- a/sonar-communityfsharp-plugin/src/main/java/org/sonar/plugins/fsharp/FSharpSensor.java
+++ b/sonar-communityfsharp-plugin/src/main/java/org/sonar/plugins/fsharp/FSharpSensor.java
@@ -111,7 +111,7 @@ public class FSharpSensor implements Sensor {
       command.addArgument("/i:" + analysisInput.getAbsolutePath())
           .addArgument("/o:" + analysisOutput.getAbsolutePath());
       LOG.debug(command.toCommandLine());
-      CommandExecutor.create().execute(command, line -> LOG.info(line), line -> LOG.error(line), Integer.MAX_VALUE);
+      CommandExecutor.create().execute(command, LOG::info, LOG::error, Integer.MAX_VALUE);
     } catch (IOException e) {
       LOG.error("Could not write settings to file '{0}'", e.getMessage());
     }

--- a/sonar-communityfsharp-plugin/src/test/java/org/sonar/plugins/fsharp/FSharpPluginTest.java
+++ b/sonar-communityfsharp-plugin/src/test/java/org/sonar/plugins/fsharp/FSharpPluginTest.java
@@ -24,7 +24,7 @@ public class FSharpPluginTest {
 
   @Test
   public void addExtensions_expectedNumber() {
-    // Arramhe
+    // Arrange
     Plugin.Context context = new Plugin.Context(mock(SonarRuntime.class));
     FSharpPlugin plugin = new FSharpPlugin();
 

--- a/sonar-communityfsharp-plugin/src/test/java/org/sonar/plugins/fsharp/FSharpSensorTest.java
+++ b/sonar-communityfsharp-plugin/src/test/java/org/sonar/plugins/fsharp/FSharpSensorTest.java
@@ -1,0 +1,48 @@
+/*
+ * Sonar FSharp Plugin, open source software quality management tool.
+ *
+ * Sonar FSharp Plugin is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * Sonar FSharp Plugin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ */
+package org.sonar.plugins.fsharp;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+
+import org.junit.Test;
+import org.sonar.api.batch.fs.FileSystem;
+import org.sonar.api.batch.sensor.Sensor;
+import org.sonar.api.batch.sensor.internal.DefaultSensorDescriptor;
+import org.sonar.api.issue.NoSonarFilter;
+import org.sonar.api.measures.FileLinesContextFactory;
+
+public class FSharpSensorTest {
+
+    @Test
+    public void describe_languageAndKey_asExpected() {
+        // Arrange
+        FsSonarRunnerExtractor extractor = new FsSonarRunnerExtractor();
+        FileSystem fs = mock(FileSystem.class);
+        FileLinesContextFactory fileLinesContextFactory = mock(FileLinesContextFactory.class);
+        NoSonarFilter noSonarFilter = new NoSonarFilter();
+        Sensor sensor = new FSharpSensor(extractor, fs, fileLinesContextFactory, noSonarFilter);
+
+        DefaultSensorDescriptor descriptor = new DefaultSensorDescriptor();
+
+        // Act
+        sensor.describe(descriptor);
+
+        // Assert
+        assertEquals(FSharpPlugin.LANGUAGE_NAME, descriptor.name());
+        assertEquals(1, descriptor.languages().size());
+        assertTrue("LANGUAGE_KEY not found", descriptor.languages().contains(FSharpPlugin.LANGUAGE_KEY));
+    }
+}


### PR DESCRIPTION
comment  on PR #73 to URI hack

> works now, however the hack 
>       sonar-fsharp-plugin/FsSonarRunner/FsSonarRunner/Program.fs
>         
>     
>          Line 70
>            |> Seq.iter (fun file -> handleFileToAnalyse(file.Replace("file:///", ""))) 
> 
>  that ive made now is cutting one extra /, so it can find any file. Do u know how to pass absolute path from java side directly? the hack was done originally because i was not able to find a way to pass absolute path from java side since they change quite a bit the api.

SonarQube gves the hint, it might be not an file URI. But otherwise, a not so elegant solution would be

          Paths.get(file.uri()).toAbsolutePath()