### PR TITLE
Feature/sonarqube7lts

### DIFF
--- a/FsSonarRunner/FsSonarRunner/FsSonarRunner.fsproj
+++ b/FsSonarRunner/FsSonarRunner/FsSonarRunner.fsproj
@@ -16,7 +16,7 @@
 
   <ItemGroup>
     <PackageReference Include="FSharp.Data" Version="3.3.3" />
-    <PackageReference Include="FSharpLint.Core" Version="0.12.6" />
+    <PackageReference Include="FSharpLint.Core" Version="0.12.7" />
   </ItemGroup>
 
   <ItemGroup>

--- a/FsSonarRunner/FsSonarRunner/FsSonarRunner.fsproj
+++ b/FsSonarRunner/FsSonarRunner/FsSonarRunner.fsproj
@@ -16,7 +16,7 @@
 
   <ItemGroup>
     <PackageReference Include="FSharp.Data" Version="3.3.3" />
-    <PackageReference Include="FSharpLint.Core" Version="0.12.7" />
+    <PackageReference Include="FSharpLint.Core" Version="0.12.10" />
   </ItemGroup>
 
   <ItemGroup>

--- a/FsSonarRunner/FsSonarRunner/FsSonarRunner.fsproj
+++ b/FsSonarRunner/FsSonarRunner/FsSonarRunner.fsproj
@@ -15,8 +15,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="FSharp.Data" Version="3.3.2" />
-    <PackageReference Include="FSharpLint.Core" Version="0.12.5" />
+    <PackageReference Include="FSharp.Data" Version="3.3.3" />
+    <PackageReference Include="FSharpLint.Core" Version="0.12.6" />
   </ItemGroup>
 
   <ItemGroup>

--- a/FsSonarRunner/FsSonarRunnerCore.Test/FsSonarRunnerCore.Test.fsproj
+++ b/FsSonarRunner/FsSonarRunnerCore.Test/FsSonarRunnerCore.Test.fsproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="Appveyor.TestLogger" Version="2.0.0" />
     <PackageReference Include="FSharp.Data" Version="3.3.3" />
-    <PackageReference Include="FSharpLint.Core" Version="0.12.7" />
+    <PackageReference Include="FSharpLint.Core" Version="0.12.10" />
     <PackageReference Include="nunit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.16.1">
       <PrivateAssets>all</PrivateAssets>

--- a/FsSonarRunner/FsSonarRunnerCore.Test/FsSonarRunnerCore.Test.fsproj
+++ b/FsSonarRunner/FsSonarRunnerCore.Test/FsSonarRunnerCore.Test.fsproj
@@ -9,11 +9,14 @@
 
   <ItemGroup>
     <PackageReference Include="Appveyor.TestLogger" Version="2.0.0" />
-    <PackageReference Include="FSharp.Data" Version="3.3.2" />
-    <PackageReference Include="FSharpLint.Core" Version="0.12.5" />
+    <PackageReference Include="FSharp.Data" Version="3.3.3" />
+    <PackageReference Include="FSharpLint.Core" Version="0.12.6" />
     <PackageReference Include="nunit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.16.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/FsSonarRunner/FsSonarRunnerCore.Test/FsSonarRunnerCore.Test.fsproj
+++ b/FsSonarRunner/FsSonarRunnerCore.Test/FsSonarRunnerCore.Test.fsproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="Appveyor.TestLogger" Version="2.0.0" />
     <PackageReference Include="FSharp.Data" Version="3.3.3" />
-    <PackageReference Include="FSharpLint.Core" Version="0.12.6" />
+    <PackageReference Include="FSharpLint.Core" Version="0.12.7" />
     <PackageReference Include="nunit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.16.1">
       <PrivateAssets>all</PrivateAssets>

--- a/FsSonarRunner/FsSonarRunnerCore.Test/Resources/LintTestFile.fs
+++ b/FsSonarRunner/FsSonarRunnerCore.Test/Resources/LintTestFile.fs
@@ -85,28 +85,23 @@ type FsLintRunner(filePath : string, rules : theSonarRules, configuration : Conf
         else
             notsupportedlines <- notsupportedlines @ [output]
 
-    let runLintOnFile pathToFile =
-        let parseInfo =
-            {
-                CancellationToken = None
-                ReceivedWarning = Some reportLintWarning
-                Configuration = Some configuration
-                ReportLinterProgress = None
-            }
-
-        lintFile parseInfo pathToFile
+    let runLintOnFile lintParams pathToFile =
+        lintFile lintParams pathToFile
 
     let outputLintResult = function
         | LintResult.Success(_) -> printfn "Lint Ok"
         | LintResult.Failure(error) -> printfn "Lint Nok %s" (error.ToString())
 
     member this.ExecuteAnalysis() =
-        issues <- List.Empty     
+        let lintParams =
+            { CancellationToken = None
+              ReceivedWarning = Some reportLintWarning
+              Configuration = Some configuration
+              ReportLinterProgress = None
+              ReleaseConfiguration = None }
+
+        issues <- List.Empty
         if File.Exists(filePath) then
-            runLintOnFile filePath |> outputLintResult
+            runLintOnFile lintParams filePath |> outputLintResult
 
         issues
-
-
-
-

--- a/FsSonarRunner/FsSonarRunnerCore/FsLintRunner.fs
+++ b/FsSonarRunner/FsSonarRunnerCore/FsLintRunner.fs
@@ -84,24 +84,23 @@ type FsLintRunner(filePath : string, rules : SonarRules, configuration : Configu
         else
             notsupportedlines <- notsupportedlines @ [output]
 
-    let runLintOnFile pathToFile =
-        let parseInfo =
-            {
-                CancellationToken = None
-                ReceivedWarning = Some reportLintWarning
-                Configuration = Some configuration
-                ReportLinterProgress = None
-            }
-
-        lintFile parseInfo pathToFile
+    let runLintOnFile lintParams pathToFile =
+        lintFile lintParams pathToFile
 
     let outputLintResult = function
         | LintResult.Success(_) -> printfn "Lint Ok"
         | LintResult.Failure(error) -> printfn "Lint Nok %s" (error.ToString())
 
     member this.ExecuteAnalysis() =
+        let lintParams =
+            { CancellationToken = None
+              ReceivedWarning = Some reportLintWarning
+              Configuration = Some configuration
+              ReportLinterProgress = None
+              ReleaseConfiguration = None }
+
         issues <- List.Empty
         if File.Exists(filePath) then
-            runLintOnFile filePath |> outputLintResult
+            runLintOnFile lintParams filePath |> outputLintResult
 
         issues

--- a/FsSonarRunner/FsSonarRunnerCore/FsSonarRunnerCore.fsproj
+++ b/FsSonarRunner/FsSonarRunnerCore/FsSonarRunnerCore.fsproj
@@ -24,8 +24,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="FSharp.Data" Version="3.3.2" />
-    <PackageReference Include="FSharpLint.Core" Version="0.12.5" />
+    <PackageReference Include="FSharp.Data" Version="3.3.3" />
+    <PackageReference Include="FSharpLint.Core" Version="0.12.6" />
   </ItemGroup>
 
   <ItemGroup>

--- a/FsSonarRunner/FsSonarRunnerCore/FsSonarRunnerCore.fsproj
+++ b/FsSonarRunner/FsSonarRunnerCore/FsSonarRunnerCore.fsproj
@@ -25,7 +25,7 @@
 
   <ItemGroup>
     <PackageReference Include="FSharp.Data" Version="3.3.3" />
-    <PackageReference Include="FSharpLint.Core" Version="0.12.6" />
+    <PackageReference Include="FSharpLint.Core" Version="0.12.7" />
   </ItemGroup>
 
   <ItemGroup>

--- a/FsSonarRunner/FsSonarRunnerCore/FsSonarRunnerCore.fsproj
+++ b/FsSonarRunner/FsSonarRunnerCore/FsSonarRunnerCore.fsproj
@@ -25,7 +25,7 @@
 
   <ItemGroup>
     <PackageReference Include="FSharp.Data" Version="3.3.3" />
-    <PackageReference Include="FSharpLint.Core" Version="0.12.7" />
+    <PackageReference Include="FSharpLint.Core" Version="0.12.10" />
   </ItemGroup>
 
   <ItemGroup>

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Download latest snapshot from Appveyor: <https://ci.appveyor.com/project/jorgeco
 
 ### Requirements
 
-- Minimal supported version of SonarQube: 6.7 LTS
+- Minimal supported version of SonarQube: 7.9 LTS
 - Working on SonarQube 8.0
 - Analyzer uses .NET Core 3.1, the corresponding depencies of .NET Core
   needs to be installed (especially on Linux). .NET Core is not

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,10 @@
 # Release Notes
 
+## v3.0.0 SonarQube 7.9 LTS
+
+- Update SonarQube API to 7.9.2 (latest SonarQube 7.9 LTS is now minimum server requirement)
+- Update to FSharpLint.Core 0.12.6
+
 ## v2.1.1 .NET Core 3.1
 
 - As EOL of .NET Core 3.0 is reached today, a small maintenance update

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,7 +3,7 @@
 ## v3.0.0 SonarQube 7.9 LTS
 
 - Update SonarQube API to 7.9.2 (latest SonarQube 7.9 LTS is now minimum server requirement)
-- Update to FSharpLint.Core 0.12.6
+- Update to FSharpLint.Core 0.12.10
 
 ## v2.1.1 .NET Core 3.1
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,7 @@
 #---------------------------------#
 
 # version format
-version: 2.1.1.{build}
+version: 3.0.0.{build}
 
 #---------------------------------#
 #    environment configuration    #

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.sonarsource.parent</groupId>
     <artifactId>parent</artifactId>
-    <version>52</version>
+    <version>53</version>
   </parent>
   <modules>
     <module>FsSonarRunner</module>
@@ -20,7 +20,7 @@
   </modules>
   <properties>
     <configuration>Debug</configuration>
-    <jacoco.version>0.8.4</jacoco.version>
+    <jacoco.version>0.8.5</jacoco.version>
   </properties>
 
   <!-- Build Settings -->
@@ -30,7 +30,7 @@
         <plugin>
           <groupId>org.sonarsource.scanner.maven</groupId>
           <artifactId>sonar-maven-plugin</artifactId>
-          <version>3.6.0.1398</version>
+          <version>3.7.0.1746</version>
           <executions>
             <execution>
               <phase>verify</phase>

--- a/sonar-communityfsharp-plugin/pom.xml
+++ b/sonar-communityfsharp-plugin/pom.xml
@@ -26,7 +26,7 @@
 
   <properties>
     <maven.test.redirectTestOutputToFile>true</maven.test.redirectTestOutputToFile>
-    <junit.jupiter.version>5.5.1</junit.jupiter.version>
+    <junit.jupiter.version>5.6.0</junit.jupiter.version>
      <maven.compiler.target>1.8</maven.compiler.target>
   </properties>
 
@@ -44,19 +44,19 @@
         <groupId>org.sonarsource.sonarqube</groupId>
         <artifactId>sonar-plugin-api</artifactId>
         <!-- minimal version of SonarQube to support. -->
-        <version>6.7</version>
+        <version>7.9</version>
         <!-- mandatory scope -->
         <scope>provided</scope>
       </dependency>
       <dependency>
         <groupId>org.codehaus.sonar</groupId>
         <artifactId>sonar-testing-harness</artifactId>
-        <version>${sonar.version}</version>
+        <version>5.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.maven</groupId>
         <artifactId>maven-project</artifactId>
-        <version>2.0.7</version>
+        <version>2.2.1</version>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -161,13 +161,13 @@
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
-      <version>3.13.1</version>
+      <version>3.15.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>3.0.0</version>
+      <version>3.3.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
- SonarQube API 7.9.2 (latest LTS 7.9)
- FSharpLint 0.12.10 (Breaking Changes in 0.12.7)

The update of SonarQube API will lead to some deprecations which need to be addressed in Issue #83

As update to FSharpLint 0.13.x broke PR #84 this is 1st part of replacement