### PR TITLE
use jdk11 on build agent

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,11 +20,9 @@ cache:
 
 # scripts that run after cloning repository
 install:
-  - echo %JAVA_HOME%
   - cmd: SET JDK_HOME=C:\Program Files\Java\jdk11
   - cmd: SET JAVA_HOME=C:\Program Files\Java\jdk11
   - cmd: mvn versions:set -DnewVersion=%APPVEYOR_BUILD_VERSION%
-  - cmd: echo %PATH%
 
 # .NET Core project files patching
 dotnet_csproj:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,7 +20,11 @@ cache:
 
 # scripts that run after cloning repository
 install:
+  - echo %JAVA_HOME%
+  - cmd: SET JDK_HOME=C:\Program Files\Java\jdk11
+  - cmd: SET JAVA_HOME=C:\Program Files\Java\jdk11
   - cmd: mvn versions:set -DnewVersion=%APPVEYOR_BUILD_VERSION%
+  - cmd: echo %PATH%
 
 # .NET Core project files patching
 dotnet_csproj:


### PR DESCRIPTION
SonarCloud: The version of Java installed in the scanner environment should be upgraded to at least Java 11 by October 2020. Pre-11 versions of Java are already deprecated and scanners using them will stop functioning after October 2020.

SonarQube 7.9 only requires Java 11 on server, not on the build agents. Therefore artefacts should still use java 8.