### PR TITLE
Update to .NET 5.0

### DIFF
--- a/FsSonarRunner/Directory.Build.props
+++ b/FsSonarRunner/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <Copyright>Copyright © 2020</Copyright>
+    <Copyright>Copyright © 2021</Copyright>
     <Product>Sonar Community F# Plugin</Product>
     <Description>The plugin enables analysis of F# within SonarQube.</Description>
     <Version>0.0.1</Version>

--- a/FsSonarRunner/FsSonarRunner/FsSonarRunner.fsproj
+++ b/FsSonarRunner/FsSonarRunner/FsSonarRunner.fsproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net50</TargetFramework>
     <!-- see https://docs.microsoft.com/en-us/dotnet/core/rid-catalog for RIds -->
     <RuntimeIdentifiers>win-x64;osx-x64;linux-x64</RuntimeIdentifiers>
     <ProjectGuid>504f4169-b41d-431f-b31e-e72e0fe2495c</ProjectGuid>

--- a/FsSonarRunner/FsSonarRunnerCore.Test/FsSonarRunnerCore.Test.fsproj
+++ b/FsSonarRunner/FsSonarRunnerCore.Test/FsSonarRunnerCore.Test.fsproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net50</TargetFramework>
     <ProjectGuid>97e76ae8-d602-400e-8f4b-0f82204c6a84</ProjectGuid>
 
     <IsPackable>false</IsPackable>

--- a/FsSonarRunner/FsSonarRunnerCore.Test/FsSonarRunnerCore.Test.fsproj
+++ b/FsSonarRunner/FsSonarRunnerCore.Test/FsSonarRunnerCore.Test.fsproj
@@ -11,11 +11,11 @@
     <PackageReference Include="Appveyor.TestLogger" Version="2.0.0" />
     <PackageReference Include="FSharp.Data" Version="3.3.3" />
     <PackageReference Include="nunit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.16.1">
+    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/FsSonarRunner/FsSonarRunnerCore/FsSonarRunnerCore.fsproj
+++ b/FsSonarRunner/FsSonarRunnerCore/FsSonarRunnerCore.fsproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>net50</TargetFramework>
     <ProjectGuid>584f069c-db4c-4561-9402-5b9b703f15a8</ProjectGuid>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>

--- a/FsSonarRunner/FsSonarRunnerCore/FsSonarRunnerCore.fsproj
+++ b/FsSonarRunner/FsSonarRunnerCore/FsSonarRunnerCore.fsproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net50</TargetFramework>
+    <TargetFrameworks>net50;netstandard2.0;netstandard2.1</TargetFrameworks>
     <ProjectGuid>584f069c-db4c-4561-9402-5b9b703f15a8</ProjectGuid>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>

--- a/FsSonarRunner/global.json
+++ b/FsSonarRunner/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "5.0.101",
+    "rollForward": "latestFeature"
+  }
+}

--- a/README.md
+++ b/README.md
@@ -15,15 +15,15 @@ Download latest snapshot from Appveyor: <https://ci.appveyor.com/project/jorgeco
 - Metrics: LOC, number of classes, number of methods
 - Code duplication detection
 - Based on [FSharpLint](http://fsprojects.github.io/FSharpLint/)
-- Runs under .NET Core 3.1 on Windows and Linux
+- Runs under .NET 5.0 on Windows and Linux
 
 ## Configuration
 
 ### Requirements
 
-- Minimal supported version of SonarQube: 7.9 LTS
-- Working on SonarQube 8.0
-- Analyzer uses .NET Core 3.1, the corresponding depencies of .NET Core
+- Minimal supported version of SonarQube: 7.9.5 LTS
+- Working on SonarQube 8.x
+- Analyzer uses .NET 5.0, the corresponding depencies of .NET
   needs to be installed (especially on Linux). .NET Core is not
   required to be installed, as the application is _self-contained_.
 - Operating system (64 bit only): Windows, Linux.

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Download latest snapshot from Appveyor: <https://ci.appveyor.com/project/jorgeco
 - Analyzer uses .NET 5.0, the corresponding depencies of .NET
   needs to be installed (especially on Linux). .NET Core is not
   required to be installed, as the application is _self-contained_.
+- NuGet packages still available also as .NET Standard 2.0/2.1 library.
 - Operating system (64 bit only): Windows, Linux.
 
 ### Installation

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,10 @@
 # Release Notes
 
-## v 3.1.x
+## v 4.0.x
+
+- BREAKING F# part as .NET 5.0 library (including nuget package)
+
+## v 3.1.384
 
 - BREAKING: Version numbering changed to Sematic Versioning 2.0 https://semver.org/ to expose FsSonarRunner as Nuget package
 - Build Nuget package of FsSonarRunnerCore

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,8 +1,8 @@
 # Release Notes
 
-## v 4.0.x
+## v 3.2.x
 
-- BREAKING F# part as .NET 5.0 library (including nuget package)
+- F# part as .NET 5.0 library (including nuget package), Nuget as netstandard2.0,  netstandard2.1 and net50
 
 ## v 3.1.384
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,7 @@
 #---------------------------------#
 
 # version format
-version: 4.0.{build}
+version: 3.2.{build}
 
 #---------------------------------#
 #    environment configuration    #

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,7 @@
 #---------------------------------#
 
 # version format
-version: 3.1.{build}
+version: 4.0.{build}
 
 #---------------------------------#
 #    environment configuration    #
@@ -101,11 +101,11 @@ artifacts:
 deploy:
   provider: NuGet
   on:
-    branch: master  
+    branch: master
   api_key:
     secure: K543ay4YetoE5FnmT4u5qd7J/5qi/C7THCrXY3A5BkKvVgjRSO96Kz6EsgB0Rui3
   skip_symbols: true
-      
+
 #---------------------------------#
 #        global handlers          #
 #---------------------------------#

--- a/sonar-communityfsharp-plugin/pom.xml
+++ b/sonar-communityfsharp-plugin/pom.xml
@@ -26,7 +26,7 @@
 
   <properties>
     <maven.test.redirectTestOutputToFile>true</maven.test.redirectTestOutputToFile>
-    <junit.jupiter.version>5.6.2</junit.jupiter.version>
+    <junit.jupiter.version>5.7.0</junit.jupiter.version>
     <maven.compiler.target>1.8</maven.compiler.target>
   </properties>
 
@@ -44,7 +44,7 @@
         <groupId>org.sonarsource.sonarqube</groupId>
         <artifactId>sonar-plugin-api</artifactId>
         <!-- minimal version of SonarQube to support. -->
-        <version>7.9</version>
+        <version>7.9.5</version>
         <!-- mandatory scope -->
         <scope>provided</scope>
       </dependency>
@@ -169,13 +169,13 @@
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
-      <version>3.16.1</version>
+      <version>3.18.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>3.3.3</version>
+      <version>3.6.28</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
Prepare for 6-month release for SonarQube

- Update to .NET 5.0 in runner, Nuget as multi-targeting library ~=> new major release (SemVer of Nuget package)~
- Update of dependencies (maven, .NET test framework)
- No upgrade of FSharpLint or F# 5.0, as `redundant new` issue is still open in Fsharp

TODO:
- [x] Test on running SonarQube instance